### PR TITLE
Revert "Add support for encryption using GPG"

### DIFF
--- a/com.github.hluk.copyq.yaml
+++ b/com.github.hluk.copyq.yaml
@@ -14,9 +14,6 @@ finish-args:
   - --device=dri
   - --filesystem=xdg-config/autostart:create
 
-  # Support for encryption with GPG
-  - --filesystem=xdg-run/gnupg:ro
-
 modules:
   - buildsystem: cmake-ninja
     config-opts:
@@ -29,28 +26,3 @@ modules:
         tag: v6.1.0
         type: git
         url: https://github.com/hluk/CopyQ.git
-
-  - name: pinentry
-    cleanup:
-      - /include
-      - /lib/debug
-      - /share/info
-      - '*.a'
-      - '*.la'
-    config-opts:
-      - --disable-fallback-curses
-      - --disable-ncurses
-      - --disable-pinentry-curses
-      - --disable-pinentry-emacs
-      - --disable-pinentry-fltk
-      - --disable-pinentry-gtk2
-      - --enable-pinentry-qt5
-      - --disable-pinentry-tqt
-      - --disable-pinentry-tty
-      - --enable-libsecret=no
-      - --disable-pinentry-gnome3
-      - --without-libcap
-    sources:
-      - type: archive
-        sha256: cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f
-        url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2


### PR DESCRIPTION
This reverts commit f7dda86979f6619b7f6cc3883927989c9d611bda.

GPG is still not working properly. Some support from flatpak side is
needed. See: https://github.com/flatpak/flatpak/issues/2301