### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.github.hluk.copyq.yaml
+++ b/com.github.hluk.copyq.yaml
@@ -10,7 +10,6 @@ finish-args:
   - --socket=wayland
   - --socket=gpg-agent
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
   - --share=ipc
   - --device=dri
 


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025