### PR TITLE
Avoid showing "Legacy windowing system" warning on flathub

### DIFF
--- a/com.github.hluk.copyq.yaml
+++ b/com.github.hluk.copyq.yaml
@@ -5,8 +5,8 @@ sdk: org.kde.Sdk
 command: copyq
 
 finish-args:
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --socket=gpg-agent
   - --talk-name=org.kde.StatusNotifierWatcher
   - --share=ipc


### PR DESCRIPTION
The app will use X11 socket only if there is no Wayland socket.