### PR TITLE
Revert "Avoid showing "Legacy windowing system" warning on flathub (#68)"

### DIFF
--- a/com.github.hluk.copyq.yaml
+++ b/com.github.hluk.copyq.yaml
@@ -5,8 +5,8 @@ sdk: org.kde.Sdk
 command: copyq
 
 finish-args:
+  - --socket=x11
   - --socket=wayland
-  - --socket=fallback-x11
   - --socket=gpg-agent
   - --talk-name=org.kde.StatusNotifierWatcher
   - --share=ipc


### PR DESCRIPTION


This reverts commit b29c9477330f835cc7a131e00ee7a12262e6a2dc.

The app may still need a simple way to switch to XWayland so the clipboard monitoring works.

Fixes https://github.com/hluk/CopyQ/issues/2948