### PR TITLE
Revert runtime version due to bug in 6.9

### DIFF
--- a/com.github.hluk.copyq.yaml
+++ b/com.github.hluk.copyq.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.hluk.copyq
 runtime: org.kde.Platform
-runtime-version: 6.9
+runtime-version: 6.8
 sdk: org.kde.Sdk
 command: copyq
 


### PR DESCRIPTION
See: https://bugreports.qt.io/browse/QTBUG-139921

Fixes https://github.com/hluk/CopyQ/issues/3160