### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/com.github.hluk.copyq.yaml
+++ b/com.github.hluk.copyq.yaml
@@ -14,6 +14,13 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
 
+cleanup:
+  - /include
+  - /lib/cmake
+  - /mkspecs
+  - /share/bash-completion
+  - /share/man
+
 modules:
   - name: qca-qt6
     buildsystem: cmake-ninja


### PR DESCRIPTION
Remove the development-related files to reduce the Flatpak size

The installed size has been reduced from **18.0 MB** to **13.4 MB**.